### PR TITLE
fix(output): #4 multiple inputs should roll into one

### DIFF
--- a/webassets_browserify/__init__.py
+++ b/webassets_browserify/__init__.py
@@ -30,26 +30,30 @@ class Browserify(ExternalTool):
 
     name = 'browserify'
     max_debug_level = None
+    method = 'output'
     options = {
         'binary': 'BROWSERIFY_BIN',
         'transforms': option('BROWSERIFY_TRANSFORMS', type=list),
         'extra_args': option('BROWSERIFY_EXTRA_ARGS', type=list)
     }
 
-    def input(self, infile, outfile, **kwargs):
-        args = [self.binary or 'browserify']
+    def setup(self):
+        super(Browserify, self).setup()
+        self.argv = [self.binary or 'browserify']
 
         for transform in self.transforms or []:
             if isinstance(transform, (list, tuple)):
-                args.extend(('--transform', '['))
-                args.extend(transform)
-                args.append(']')
+                self.argv.extend(('--transform', '['))
+                self.argv.extend(transform)
+                self.argv.append(']')
             else:
-                args.extend(('--transform', transform))
+                self.argv.extend(('--transform', transform))
 
         if self.extra_args:
-            args.extend(self.extra_args)
+            self.argv.extend(self.extra_args)
 
-        args.append(kwargs['source_path'])
+    def input(self, infile, outfile, **kwargs):
+        self.argv.append(kwargs['source_path'])
 
-        self.subprocess(args, outfile, infile)
+    def output(self, infile, outfile, **kwargs):
+        self.subprocess(self.argv, outfile, infile)


### PR DESCRIPTION
This addresses #4 

Inputs are added to self.argv and when output() is called, instead a subprocess is made.

Note, this isn't as efficient as creating partial results for each globbing and then later running browserify and as a subprocess and telling it to combine things... but I'm unfamiliar with how to engineer that.

Feel free to provide suggestions.

This code has ONLY been tested on python 2.7.10 with flask and flask-assets from pip latest stable.

If you need a test repo, I could furnish one in approximately a week (busy and this was done with private repos atm)
